### PR TITLE
プロンプトをJSONモードに最適化

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -2,3 +2,4 @@ OPENAI_API_KEY=sk-xxx
 GPT_MODEL=gpt-4o-mini
 
 GITHUB_TOKEN=ghp_xxx
+REPOSITORY_PATH=owner/repository

--- a/main.py
+++ b/main.py
@@ -13,23 +13,26 @@ zcode = input('郵便番号を入力してください: ')
 address = zipcode.get(zcode).json()
 
 prompt = f"""
-{address}のエリアに応じて出力を変えてください。
-ただし、出力は必ず1文字の数字であること。
-エリア: 出力する値 の対応表は以下です。
+{address}のエリアに応じて<<area>>をjson形式で出力してください。
+ただし、<<area>>は必ず1文字の数字であること。
+エリア: <<area>> の対応表は以下です。
 関東: 1,
 関西: 2,
 その他: 3
+
+[出力項目]
+area: <<area>>
 """
 
 gpt_responce = gpt.post(prompt, temperature=0.0)
-area = gpt.content(gpt_responce)
+area = int(gpt.content(gpt_responce)['area'])
 
 try:
-    if area == '1':
+    if area == 1:
         print('関東〜〜〜〜〜！！！')
-    elif area == '2':
+    elif area == 2:
         print('関西〜〜〜〜〜！！！')
-    elif area == '3':
+    elif area == 3:
         area / 0 # ゼロ除算エラーを発生させる
 except Exception as e:
     script_path = os.path.basename(__file__)

--- a/modules/config.py
+++ b/modules/config.py
@@ -7,3 +7,4 @@ OPENAI_API_KEY = os.getenv('OPENAI_API_KEY')
 GPT_MODEL = os.getenv('GPT_MODEL')
 
 GITHUB_TOKEN = os.getenv('GITHUB_TOKEN')
+REPOSITORY_PATH = os.getenv('REPOSITORY_PATH')

--- a/modules/github_api.py
+++ b/modules/github_api.py
@@ -2,14 +2,12 @@ from modules import config
 from github import Github
 from github import Auth
 
-access_token = config.GITHUB_TOKEN
-auth = Auth.Token(access_token)
+ACCESS_TOKEN = config.GITHUB_TOKEN
+REPOSITORY_PATH = config.REPOSITORY_PATH
+auth = Auth.Token(ACCESS_TOKEN)
 
 g = Github(auth=auth)
-
-owner = "ysk91"
-repository = "mva-demo"
-repo = g.get_repo(f"{owner}/{repository}")
+repo = g.get_repo(REPOSITORY_PATH)
 
 def create_issue(title, body):
     issue = repo.create_issue(

--- a/modules/openai_api.py
+++ b/modules/openai_api.py
@@ -28,3 +28,10 @@ def post(prompt, temperature=0.7):
 def content(response):
     content = response['choices'][0]['message']['content']
     return json.loads(content) if content else None
+
+## Hack
+# OpenAI APIをJSONモードで使用しているため、プロンプト内でJSONで出力するように指示する必要がある。
+# {'error': {'message': "'messages' must contain the word 'json' in some form, to use 'response_format' of type 'json_object'.", 'type': 'invalid_request_error', 'param': 'messages', 'code': None}}
+# その際、出力形式でキーと値を指定する。
+# contentから任意の値を使用するには、取得したJSON形式の値に対してキーで抜き出す。
+# JSON内の値は文字列であることに注意する。


### PR DESCRIPTION
## 実装内容

### 発生事例

main.pyで関東エリアを入力したところ、以下が発生

```
{'error': {'message': "'messages' must contain the word 'json' in some form, to use 'response_format' of type 'json_object'.", 'type': 'invalid_request_error', 'param': 'messages', 'code': None}}
```

### 対応

OpenAI APIをJSONモードで使用しているため、プロンプト内でJSONで出力するように指示する必要がある
その際、出力形式でキーと値を指定する。
contentから任意の値を使用するには、取得したJSON形式の値に対してキーで抜き出す。
JSON内の値は文字列であることに注意する。

## 確認

```
ysk@YusukenoMacBook-Air mva-demo % python main.py
郵便番号を入力してください: 9500001
Skipping __pycache__ (not found in repo)
Issue created: https://github.com/ysk91/mva-demo/issues/14
ysk@YusukenoMacBook-Air mva-demo % python main.py
郵便番号を入力してください: 1000001
関東〜〜〜〜〜！！！
```